### PR TITLE
Feat gc

### DIFF
--- a/lox-programs/test.lox
+++ b/lox-programs/test.lox
@@ -3,6 +3,7 @@ print "st" + "st" + "ri" + "ng";
 var beverage = "cafe au lait";
 var breakfast = "beignets with " + beverage;
 print breakfast;
+print "hello, world";
 
 {
   var a = "outer";

--- a/src/compile.zig
+++ b/src/compile.zig
@@ -17,7 +17,6 @@ const obj = @import("object.zig");
 const Obj = obj.Obj;
 const new_function = obj.new_function;
 const new_string = obj.new_string;
-const alloc_string = obj.alloc_string;
 
 const ObjStringHashMap = @import("vm.zig").ObjStringHashMap;
 
@@ -195,11 +194,13 @@ pub const Compiler = struct {
         compiler.mark_initialized();
 
         if (function_type != FunctionType.script) {
-            function_obj.as_function().name = alloc_string(
+            function_obj.as_function().name = new_string(
                 strings,
                 parser.previous.start[0..parser.previous.length],
+                objects,
                 allocator,
-            );
+                false,
+            ).as_string();
         }
 
         return compiler;

--- a/src/gc.zig
+++ b/src/gc.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const GCAllocator = struct {
+    backing_allocator: Allocator,
+
+    debug_stress: bool,
+    debug_log: bool,
+
+    pub fn init(
+        backing_allocator: Allocator,
+        debug_stress: bool,
+        debug_log: bool,
+    ) GCAllocator {
+        return GCAllocator{
+            .backing_allocator = backing_allocator,
+            .debug_stress = debug_stress,
+            .debug_log = debug_log,
+        };
+    }
+
+    pub fn allocator(self: *GCAllocator) Allocator {
+        return Allocator.init(self, alloc, resize, free);
+    }
+
+    fn collect_garbage(self: *GCAllocator) void {
+        if (self.debug_log) {
+            std.debug.print("-- gc begin \n", .{});
+        }
+
+        if (self.debug_log) {
+            std.debug.print("-- gc end \n", .{});
+        }
+    }
+
+    fn mark_roots(self: *GCAllocator) void {
+        _ = self;
+        // todo
+    }
+
+    fn alloc(
+        self: *GCAllocator,
+        len: usize,
+        ptr_align: u29,
+        len_align: u29,
+        ret_addr: usize,
+    ) Allocator.Error![]u8 {
+        if (self.debug_stress) self.collect_garbage();
+        const res = try self.backing_allocator.rawAlloc(len, ptr_align, len_align, ret_addr);
+        if (self.debug_log) {
+            std.debug.print("{*} allocate {d}\n", .{ res, len });
+        }
+        return res;
+    }
+
+    fn resize(
+        self: *GCAllocator,
+        old_mem: []u8,
+        old_align: u29,
+        new_size: usize,
+        len_align: u29,
+        ret_addr: usize,
+    ) ?usize {
+        if (self.debug_stress and new_size > old_mem.len) self.collect_garbage();
+        const res = self.backing_allocator.rawResize(old_mem, old_align, new_size, len_align, ret_addr);
+        if (self.debug_log and res != null) {
+            std.debug.print("{*} resized from {d} to {d}\n", .{
+                old_mem,
+                old_mem.len,
+                new_size,
+            });
+        }
+        return res;
+    }
+
+    fn free(
+        self: *GCAllocator,
+        old_mem: []u8,
+        old_align: u29,
+        ret_addr: usize,
+    ) void {
+        self.backing_allocator.rawFree(old_mem, old_align, ret_addr);
+        if (self.debug_log) {
+            std.debug.print("{*} freed {d}\n", .{ old_mem, old_mem.len });
+        }
+    }
+};

--- a/src/lox.zig
+++ b/src/lox.zig
@@ -1,5 +1,35 @@
 // this file is the entrypoint for the lox-zig library
-const vm = @import("vm.zig");
-pub const VM = vm.VM;
-pub const Options = vm.Options;
-pub const InterpretError = vm.InterpretError;
+const std = @import("std");
+
+const vml = @import("vm.zig");
+pub const VM = vml.VM;
+pub const Options = vml.Options;
+pub const InterpretError = vml.InterpretError;
+const GCAllocator = @import("gc.zig").GCAllocator;
+
+pub const Lox = struct {
+    vm: ?VM = null,
+    options: Options,
+    gc: GCAllocator,
+
+    pub fn init(options: Options, allocator: std.mem.Allocator) Lox {
+        var gc = GCAllocator.init(
+            allocator,
+            options.debug_stress_gc,
+            options.debug_gc,
+        );
+        return Lox{ .gc = gc, .options = options };
+    }
+
+    pub fn deinit(self: *Lox) void {
+        if (self.vm) |*vm| vm.deinit();
+    }
+
+    pub fn interpret(self: *Lox, source: []const u8) InterpretError!void {
+        if (self.vm == null) {
+            self.vm = VM.init(self.options, &self.gc);
+            self.gc.vm = &self.vm.?;
+        }
+        return self.vm.?.interpret(source);
+    }
+};

--- a/src/lox.zig
+++ b/src/lox.zig
@@ -1,4 +1,5 @@
 // this file is the entrypoint for the lox-zig library
-pub const chunk = @import("chunk.zig");
-pub const VM = @import("vm.zig").VM;
-pub const InterpretError = @import("vm.zig").InterpretError;
+const vm = @import("vm.zig");
+pub const VM = vm.VM;
+pub const Options = vm.Options;
+pub const InterpretError = vm.InterpretError;

--- a/src/lox.zig
+++ b/src/lox.zig
@@ -23,6 +23,7 @@ pub const Lox = struct {
 
     pub fn deinit(self: *Lox) void {
         if (self.vm) |*vm| vm.deinit();
+        self.gc.deinit();
     }
 
     pub fn interpret(self: *Lox, source: []const u8) InterpretError!void {

--- a/src/object.zig
+++ b/src/object.zig
@@ -42,14 +42,14 @@ pub const ObjType = union(enum) {
                 allocator.destroy(self.string);
             },
             .function => {
-                self.function.deinit(allocator);
+                self.function.deinit();
                 allocator.destroy(self.function);
             },
             .native => {
                 allocator.destroy(self.native);
             },
             .closure => {
-                self.closure.deinit(allocator);
+                self.closure.deinit();
                 allocator.destroy(self.closure);
             },
             .upvalue => {
@@ -268,7 +268,7 @@ pub const ObjFunction = struct {
         return .{ .chunk = chunk };
     }
 
-    pub fn deinit(self: *ObjFunction, _: std.mem.Allocator) void {
+    pub fn deinit(self: *ObjFunction) void {
         self.chunk.deinit();
     }
 
@@ -307,6 +307,8 @@ pub const ObjClosure = struct {
     function: *ObjFunction,
     upvalues: []?*ObjUpValue,
 
+    allocator: std.mem.Allocator,
+
     pub fn init(
         function: *ObjFunction,
         allocator: std.mem.Allocator,
@@ -318,11 +320,15 @@ pub const ObjClosure = struct {
         );
         std.mem.set(?*ObjUpValue, upvalues, null);
 
-        return ObjClosure{ .function = function, .upvalues = upvalues };
+        return ObjClosure{
+            .function = function,
+            .upvalues = upvalues,
+            .allocator = allocator,
+        };
     }
 
-    pub fn deinit(self: *ObjClosure, allocator: std.mem.Allocator) void {
-        allocator.free(self.upvalues);
+    pub fn deinit(self: *ObjClosure) void {
+        self.allocator.free(self.upvalues);
     }
 
     pub fn format(

--- a/src/object.zig
+++ b/src/object.zig
@@ -251,7 +251,7 @@ pub fn new_string(
     return alloc_obj(objt, objects, allocator);
 }
 
-pub fn alloc_string(
+fn alloc_string(
     strings: *ObjStringHashMap,
     string: []const u8,
     allocator: std.mem.Allocator,
@@ -260,7 +260,7 @@ pub fn alloc_string(
     return get_or_put_interned_string(strings, &new_objstr, allocator);
 }
 
-pub fn take_string(
+fn take_string(
     strings: *ObjStringHashMap,
     data: []const u8,
     allocator: std.mem.Allocator,
@@ -351,7 +351,7 @@ pub const ObjClosure = struct {
         _ = fmt;
         _ = options;
 
-        try writer.print("{}", .{self.function});
+        try writer.print("{} (closure)", .{self.function});
     }
 };
 

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -20,7 +20,8 @@ pub fn main() anyerror!void {
     defer std.process.argsFree(allocator, args);
 
     // TODO: put debug bool behind an args flag
-    const options = lox.Options.init_all();
+    var options = lox.Options.init_all();
+    // options.debug_stress_gc = false;
     var vm = lox.Lox.init(options, allocator);
     defer vm.deinit();
 

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -21,7 +21,7 @@ pub fn main() anyerror!void {
 
     // TODO: put debug bool behind an args flag
     const options = lox.Options.init_all();
-    var vm = lox.VM.init(options, allocator);
+    var vm = lox.Lox.init(options, allocator);
     defer vm.deinit();
 
     switch (args.len) {
@@ -47,7 +47,7 @@ fn next_line(reader: anytype, buffer: []u8) ?[]const u8 {
     }
 }
 
-fn repl(vm: *lox.VM) void {
+fn repl(vm: *lox.Lox) void {
     const stdout = std.io.getStdOut();
     const stdin = std.io.getStdIn();
 
@@ -74,7 +74,7 @@ fn repl(vm: *lox.VM) void {
     }
 }
 
-fn run_file(vm: *lox.VM, allocator: std.mem.Allocator, path: []u8) void {
+fn run_file(vm: *lox.Lox, allocator: std.mem.Allocator, path: []u8) void {
     const file = std.fs.cwd().openFile(path, .{}) catch {
         std.debug.print("Could not open file", .{});
         std.process.exit(74);

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -20,8 +20,8 @@ pub fn main() anyerror!void {
     defer std.process.argsFree(allocator, args);
 
     // TODO: put debug bool behind an args flag
-    const debug = true;
-    var vm = lox.VM.init(debug, allocator);
+    const options = lox.Options.init_all();
+    var vm = lox.VM.init(options, allocator);
     defer vm.deinit();
 
     switch (args.len) {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -103,12 +103,8 @@ pub const VM = struct {
 
     options: Options,
 
-    pub fn init(options: Options, allocator: std.mem.Allocator) VM {
-        const gc_allocator = GCAllocator.init(
-            allocator,
-            options.debug_stress_gc,
-            options.debug_gc,
-        ).allocator();
+    pub fn init(options: Options, gc: *GCAllocator) VM {
+        const gc_allocator = gc.allocator();
         const strings = ObjStringHashMap.init(gc_allocator);
         const globals = VariableHashMap.init(gc_allocator);
         var vm = VM{

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -385,7 +385,7 @@ pub const VM = struct {
 
     fn concatenate(self: *VM) InterpretError!void {
         const b: []const u8 = self.peek(0).as_obj().as_string().data;
-        const a: []const u8 = self.peek(0).as_obj().as_string().data;
+        const a: []const u8 = self.peek(1).as_obj().as_string().data;
         const data = std.mem.concat(self.allocator, u8, &[_][]const u8{ a, b }) catch {
             self.runtime_error("out of memory\n", .{});
             return InterpretError.runtime;


### PR DESCRIPTION
* Create custom allocator which performs GC.  It backs an allocator passed in from user-land.
* Mark and Sweep garbage collection
* Add `Option` struct to improve granularity of debugging
* Add `header` field to all object implementations to allow marking and sweeping the `Obj` associated with it (come back to this someday - very memory inefficient)
* Add small `Lox` struct at the top level API to make sure the bi-directional gc and vm pointers have the correct lifetimes