### PR TITLE
packed value type

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,10 +4,15 @@ pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
 
+    const value_union = b.option(bool, "value-union", "use union values instead of packed values") orelse false;
+    
+    const exe_options = b.addOptions();
+    exe_options.addOption(bool, "value_union", value_union);
+
     const exe = b.addExecutable("lox", "src/runner.zig");
-    exe.addPackagePath("lox", "src/lox.zig");
     exe.setTarget(target);
     exe.setBuildMode(mode);
+    exe.addOptions("build_options", exe_options);
     exe.install();
 
     const run_cmd = exe.run();

--- a/lox-programs/zoo.lox
+++ b/lox-programs/zoo.lox
@@ -1,0 +1,31 @@
+class Zoo {
+  init() {
+    this.aardvark = 1;
+    this.baboon   = 1;
+    this.cat      = 1;
+    this.donkey   = 1;
+    this.elephant = 1;
+    this.fox      = 1;
+  }
+  ant()    { return this.aardvark; }
+  banana() { return this.baboon; }
+  tuna()   { return this.cat; }
+  hay()    { return this.donkey; }
+  grass()  { return this.elephant; }
+  mouse()  { return this.fox; }
+}
+
+var zoo = Zoo();
+var sum = 0;
+var start = clock();
+while (sum < 100000000) {
+  sum = sum + zoo.ant()
+            + zoo.banana()
+            + zoo.tuna()
+            + zoo.hay()
+            + zoo.grass()
+            + zoo.mouse();
+}
+
+print clock() - start;
+print sum;

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -1,7 +1,7 @@
 // this file is the entrypoint for the executable zig binary
 const std = @import("std");
 
-const lox = @import("lox");
+const lox = @import("lox.zig");
 const InterpretError = lox.InterpretError;
 
 pub fn main() anyerror!void {
@@ -21,6 +21,7 @@ pub fn main() anyerror!void {
 
     // TODO: put debug bool behind an args flag
     var options = lox.Options.init_all();
+    options = lox.Options{};
     options.debug_stress_gc = false;
     options.debug_gc = false;
     var vm = lox.Lox.init(options, allocator);

--- a/src/value.zig
+++ b/src/value.zig
@@ -1,11 +1,143 @@
 const std = @import("std");
 const ArrayList = std.ArrayList;
 
+const build_options = @import("build_options");
+
 const common = @import("common.zig");
 const obj = @import("object.zig");
 const Obj = obj.Obj;
 
-pub const Value = union(enum) {
+pub const Value = if (build_options.value_union) ValueUnion else ValuePack;
+
+const ValuePack = union(enum) {
+    payload: u64,
+
+    const QNAN: u64 = 0x7ffc000000000000;
+    const SIGN_BIT: u64 = 0x8000000000000000;
+    const TAG_NIL: u64 = 1;
+    const TAG_FALSE: u64 = 2;
+    const TAG_TRUE: u64 = 3;
+    const VAL_NIL: u64 = QNAN | TAG_NIL;
+    const VAL_FALSE: u64 = QNAN | TAG_FALSE;
+    const VAL_TRUE: u64 = QNAN | TAG_TRUE;
+
+    pub fn number(val: f64) Value {
+        return Value{ .payload = @bitCast(u64, val) };
+    }
+
+    pub fn boolean(val: bool) Value {
+        return Value{ .payload = if (val) VAL_TRUE else VAL_FALSE };
+    }
+
+    pub fn nil() Value {
+        return Value{ .payload = VAL_NIL };
+    }
+
+    pub fn obj(val: *Obj) Value {
+        return Value{ .payload = QNAN | SIGN_BIT | @ptrToInt(val) };
+    }
+
+    pub fn as_number(self: Value) f64 {
+        return @bitCast(f64, self.payload);
+    }
+
+    pub fn as_boolean(self: Value) bool {
+        return self.payload == VAL_TRUE;
+    }
+
+    pub fn as_obj(self: Value) *Obj {
+        return @intToPtr(*Obj, self.payload & ~(SIGN_BIT | QNAN));
+    }
+
+    pub fn is_number(self: Value) bool {
+        return (self.payload & QNAN) != QNAN;
+    }
+
+    pub fn is_boolean(self: Value) bool {
+        return (self.payload | 1) == VAL_TRUE;
+    }
+
+    pub fn is_nil(self: Value) bool {
+        return self.payload == VAL_NIL;
+    }
+
+    pub fn is_obj(self: Value) bool {
+        return (self.payload & (QNAN | SIGN_BIT)) == (QNAN | SIGN_BIT);
+    }
+
+    fn is_obj_type(self: Value, comptime field: [:0]const u8) bool {
+        if (self.is_obj()) {
+            return std.mem.eql(u8, @tagName(self.as_obj().t), field);
+        }
+
+        return false;
+    }
+
+    pub fn is_string(self: Value) bool {
+        return self.is_obj_type("string");
+    }
+
+    pub fn is_function(self: Value) bool {
+        return self.is_obj_type("function");
+    }
+
+    pub fn is_native(self: Value) bool {
+        return self.is_obj_type("native");
+    }
+
+    pub fn is_closure(self: Value) bool {
+        return self.is_obj_type("closure");
+    }
+
+    pub fn is_upvalue(self: Value) bool {
+        return self.is_obj_type("upvalue");
+    }
+
+    pub fn is_class(self: Value) bool {
+        return self.is_obj_type("class");
+    }
+
+    pub fn is_instance(self: Value) bool {
+        return self.is_obj_type("instance");
+    }
+
+    pub fn is_bound_method(self: Value) bool {
+        return self.is_obj_type("bound_method");
+    }
+
+    pub fn is_falsey(self: Value) bool {
+        return self.is_nil() or (self.is_boolean() and !self.as_boolean());
+    }
+
+    pub fn equals(self: Value, other: Value) bool {
+        if (self.is_number() and other.is_number()) {
+            return self.as_number() == other.as_number();
+        }
+        return self.payload == other.payload;
+    }
+
+    pub fn format(
+        self: Value,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+
+        if (self.is_boolean()) {
+            try writer.print("{}", .{self.as_boolean()});
+        } else if (self.is_nil()) {
+            try writer.print("nil", .{});
+        } else if (self.is_number()) {
+            try writer.print("{d}", .{self.as_number()});
+        } else {
+            try writer.print("{}", .{self.as_obj()});
+        }
+    }
+};
+
+const ValueUnion = union(enum) {
     val_boolean: bool,
     val_nil: void,
     val_number: f64,


### PR DESCRIPTION
Instead of a tagged union, represent all `Value` types using a 64-bit number.  Takes advantage of IEEE floating point representation to encode the non-number types using the lower bits when the NaN bits are all set.