### PR TITLE
Refactor objects

### DIFF
--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -94,7 +94,7 @@ pub const Chunk = struct {
         value: T,
     ) void {
         list.append(self.allocator, value) catch {
-            std.debug.print("Out of memory\n", .{});
+            std.log.err("Out of memory\n", .{});
             std.process.exit(1);
         };
     }

--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -1,9 +1,6 @@
 const std = @import("std");
-const ArrayList = std.ArrayList;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
 
-const common = @import("common.zig");
-
-const ValueArray = @import("value.zig").ValueArray;
 const Value = @import("value.zig").Value;
 
 pub const OpCode = enum(u8) {
@@ -57,36 +54,48 @@ pub const OpCode = enum(u8) {
 
 // this should maybe be ArrayList instead
 pub const Chunk = struct {
-    code: ArrayList(u8),
-    lines: ArrayList(usize),
-    constants: ValueArray,
+    code: ArrayListUnmanaged(u8) = ArrayListUnmanaged(u8){},
+    lines: ArrayListUnmanaged(usize) = ArrayListUnmanaged(usize){},
+    constants: ArrayListUnmanaged(Value) = ArrayListUnmanaged(Value){},
+
+    allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) Chunk {
         return Chunk{
-            .code = ArrayList(u8).init(allocator),
-            .lines = ArrayList(usize).init(allocator),
-            .constants = ValueArray.init(allocator),
+            .allocator = allocator,
         };
     }
 
     pub fn deinit(self: *Chunk) void {
-        self.code.deinit();
-        self.lines.deinit();
-        self.constants.deinit();
+        self.code.deinit(self.allocator);
+        self.lines.deinit(self.allocator);
+        self.constants.deinit(self.allocator);
     }
 
     // if we're out of memory, bail out
     pub fn write(self: *Chunk, byte: u8, line: usize) void {
-        common.write_or_die(u8, &self.code, byte);
-        common.write_or_die(usize, &self.lines, line);
+        self.write_or_die(u8, &self.code, byte);
+        self.write_or_die(usize, &self.lines, line);
     }
 
     pub fn add_constant(self: *Chunk, value: Value) usize {
-        self.constants.write(value);
-        return self.constants.length() - 1;
+        self.write_or_die(Value, &self.constants, value);
+        return self.constants.items.len - 1;
     }
 
     pub fn length(self: *Chunk) usize {
         return self.code.items.len;
+    }
+
+    fn write_or_die(
+        self: *Chunk,
+        comptime T: type,
+        list: *ArrayListUnmanaged(T),
+        value: T,
+    ) void {
+        list.append(self.allocator, value) catch {
+            std.debug.print("Out of memory\n", .{});
+            std.process.exit(1);
+        };
     }
 };

--- a/src/common.zig
+++ b/src/common.zig
@@ -4,28 +4,28 @@ const exit = std.process.exit;
 
 pub fn write_or_die(comptime T: type, list: *ArrayList(T), value: T) void {
     list.append(value) catch {
-        std.debug.print("Out of memory\n", .{});
+        std.log.err("Out of memory\n", .{});
         exit(1);
     };
 }
 
 pub fn alloc_or_die(allocator: std.mem.Allocator, comptime T: type, len: usize) []T {
     return allocator.alloc(T, len) catch {
-        std.debug.print("Out of memory\n", .{});
+        std.log.err("Out of memory\n", .{});
         std.process.exit(1);
     };
 }
 
 pub fn alloc_aligned_or_die(allocator: std.mem.Allocator, len: usize) []align(8) u8 {
     return allocator.alignedAlloc(u8, 8, len) catch {
-        std.debug.print("Out of memory\n", .{});
+        std.log.err("Out of memory\n", .{});
         std.process.exit(1);
     };
 }
 
 pub fn create_or_die(allocator: std.mem.Allocator, comptime T: type) *T {
     return allocator.create(T) catch {
-        std.debug.print("Out of memory\n", .{});
+        std.log.err("Out of memory\n", .{});
         std.process.exit(1);
     };
 }

--- a/src/common.zig
+++ b/src/common.zig
@@ -16,6 +16,13 @@ pub fn alloc_or_die(allocator: std.mem.Allocator, comptime T: type, len: usize) 
     };
 }
 
+pub fn alloc_aligned_or_die(allocator: std.mem.Allocator, len: usize) []align(8) u8 {
+    return allocator.alignedAlloc(u8, 8, len) catch {
+        std.debug.print("Out of memory\n", .{});
+        std.process.exit(1);
+    };
+}
+
 pub fn create_or_die(allocator: std.mem.Allocator, comptime T: type) *T {
     return allocator.create(T) catch {
         std.debug.print("Out of memory\n", .{});

--- a/src/compile.zig
+++ b/src/compile.zig
@@ -18,6 +18,8 @@ const Obj = obj.Obj;
 const new_function = obj.new_function;
 const new_string = obj.new_string;
 
+const log = std.log.scoped(.compiler);
+
 const ObjStringHashMap = @import("vm.zig").ObjStringHashMap;
 
 const compile_err = error.CompileFailed;
@@ -1048,18 +1050,18 @@ const Parser = struct {
 
         self.panic_mode = true;
 
-        std.log.err("[line {d}] Error", .{token.line});
+        log.err("[line {d}] Error", .{token.line});
 
         switch (token.t) {
-            .eof => std.log.err(" at end", .{}),
+            .eof => log.err(" at end", .{}),
             .scan_error => {},
-            else => std.log.err(" at {s}", .{token.start[0..token.length]}),
+            else => log.err(" at {s}", .{token.start[0..token.length]}),
         }
 
         // if there is no message, use the token content, which in the case of scan_error token's
         // is actually the message itself
         const message_str: []const u8 = message orelse token.start[0..token.length];
-        std.log.err(": {s}\n", .{message_str});
+        log.err(": {s}\n", .{message_str});
         self.had_error = true;
     }
 };

--- a/src/compile.zig
+++ b/src/compile.zig
@@ -963,7 +963,7 @@ pub const Compiler = struct {
     fn end(self: *Compiler) *Obj {
         self.emit_return();
         if (self.debug and !self.parser.had_error) {
-            disassemble_chunk(self.current_chunk(), self.function);
+            disassemble_chunk(self.current_chunk(), self.function.as_function());
         }
 
         return self.function;

--- a/src/compile.zig
+++ b/src/compile.zig
@@ -1048,18 +1048,18 @@ const Parser = struct {
 
         self.panic_mode = true;
 
-        std.debug.print("[line {d}] Error", .{token.line});
+        std.log.err("[line {d}] Error", .{token.line});
 
         switch (token.t) {
-            .eof => std.debug.print(" at end", .{}),
+            .eof => std.log.err(" at end", .{}),
             .scan_error => {},
-            else => std.debug.print(" at {s}", .{token.start[0..token.length]}),
+            else => std.log.err(" at {s}", .{token.start[0..token.length]}),
         }
 
         // if there is no message, use the token content, which in the case of scan_error token's
         // is actually the message itself
         const message_str: []const u8 = message orelse token.start[0..token.length];
-        std.debug.print(": {s}\n", .{message_str});
+        std.log.err(": {s}\n", .{message_str});
         self.had_error = true;
     }
 };

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -6,7 +6,7 @@ const OpCode = chunk.OpCode;
 const read_short = @import("common.zig").read_short;
 
 pub fn disassemble_chunk(c: *Chunk, name: anytype) void {
-    std.debug.print("==={s}===\n", .{name});
+    std.log.debug("==={s}===\n", .{name});
 
     var offset: usize = 0;
     while (offset < c.length()) {
@@ -15,13 +15,13 @@ pub fn disassemble_chunk(c: *Chunk, name: anytype) void {
 }
 
 pub fn disassemble_instruction(c: *Chunk, offset: usize) usize {
-    std.debug.print("{d:0>4} ", .{offset});
+    std.log.debug("{d:0>4} ", .{offset});
 
     // print line number
     if ((offset > 0) and (c.lines.items[offset] == c.lines.items[offset - 1])) {
-        std.debug.print("   | ", .{});
+        std.log.debug("   | ", .{});
     } else {
-        std.debug.print("{d: >4} ", .{c.lines.items[offset]});
+        std.log.debug("{d: >4} ", .{c.lines.items[offset]});
     }
 
     const instruction_byte = c.code.items[offset];
@@ -76,13 +76,13 @@ pub fn disassemble_instruction(c: *Chunk, offset: usize) usize {
 }
 
 pub fn simple_instruction(name: []const u8, offset: usize) usize {
-    std.debug.print("{s}\n", .{name});
+    std.log.debug("{s}\n", .{name});
     return offset + 1;
 }
 
 pub fn constant_instruction(name: []const u8, c: *Chunk, offset: usize) usize {
     const constant_idx: usize = c.code.items[offset + 1];
-    std.debug.print(
+    std.log.debug(
         "{s: <16} {d: >4} '{}'\n",
         .{ name, constant_idx, c.constants.items[constant_idx] },
     );
@@ -96,7 +96,7 @@ pub fn closure_instruction(
 ) usize {
     var offset = original_offset + 1;
     const constant_idx: usize = c.code.items[offset];
-    std.debug.print(
+    std.log.debug(
         "{s: <16} {d: >4} '{}'\n",
         .{ name, constant_idx, c.constants.items[constant_idx] },
     );
@@ -107,7 +107,7 @@ pub fn closure_instruction(
     while (i < function.upvalue_count) : (i += 1) {
         const is_local = if (c.code.items[offset] == 1) "local" else "upvalue";
         const index = c.code.items[offset + 1];
-        std.debug.print(
+        std.log.debug(
             "{d:0>4}      |                     {s} {d}\n",
             .{ offset, is_local, index },
         );
@@ -119,7 +119,7 @@ pub fn closure_instruction(
 
 fn byte_instruction(name: []const u8, c: *Chunk, offset: usize) usize {
     const byte_idx: usize = c.code.items[offset + 1];
-    std.debug.print("{s: <16} {d: >4}\n", .{ name, byte_idx });
+    std.log.debug("{s: <16} {d: >4}\n", .{ name, byte_idx });
     return offset + 2;
 }
 
@@ -131,7 +131,7 @@ fn jump_instruction(
 ) usize {
     const jump_size = read_short(.{ c.code.items[offset + 1], c.code.items[offset + 2] });
     const sign: i32 = if (positive_jump) 1 else -1;
-    std.debug.print("{s: <16} {d: >4} -> {d}\n", .{ name, offset, @intCast(i32, offset + 3) + sign * jump_size });
+    std.log.debug("{s: <16} {d: >4} -> {d}\n", .{ name, offset, @intCast(i32, offset + 3) + sign * jump_size });
     return offset + 3;
 }
 
@@ -142,7 +142,7 @@ fn invoke_instruction(
 ) usize {
     const constant_idx: usize = c.code.items[offset + 1];
     const arg_count: usize = c.code.items[offset + 2];
-    std.debug.print(
+    std.log.debug(
         "{s: <16} ({d} args) {d: >4} '{s}'\n",
         .{ name, arg_count, constant_idx, c.constants.items[constant_idx] },
     );

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -84,7 +84,7 @@ pub fn constant_instruction(name: []const u8, c: *Chunk, offset: usize) usize {
     const constant_idx: usize = c.code.items[offset + 1];
     std.debug.print(
         "{s: <16} {d: >4} '{}'\n",
-        .{ name, constant_idx, c.constants.values.items[constant_idx] },
+        .{ name, constant_idx, c.constants.items[constant_idx] },
     );
     return offset + 2;
 }
@@ -98,11 +98,11 @@ pub fn closure_instruction(
     const constant_idx: usize = c.code.items[offset];
     std.debug.print(
         "{s: <16} {d: >4} '{}'\n",
-        .{ name, constant_idx, c.constants.values.items[constant_idx] },
+        .{ name, constant_idx, c.constants.items[constant_idx] },
     );
     offset += 1;
 
-    var function = c.constants.values.items[constant_idx].as_obj().as_function();
+    var function = c.constants.items[constant_idx].as_obj().as_function();
     var i: u8 = 0;
     while (i < function.upvalue_count) : (i += 1) {
         const is_local = if (c.code.items[offset] == 1) "local" else "upvalue";
@@ -144,7 +144,7 @@ fn invoke_instruction(
     const arg_count: usize = c.code.items[offset + 2];
     std.debug.print(
         "{s: <16} ({d} args) {d: >4} '{s}'\n",
-        .{ name, arg_count, constant_idx, c.constants.values.items[constant_idx] },
+        .{ name, arg_count, constant_idx, c.constants.items[constant_idx] },
     );
     return offset + 3;
 }

--- a/src/gc.zig
+++ b/src/gc.zig
@@ -7,7 +7,8 @@ const VariableHashMap = @import("vm.zig").VariableHashMap;
 
 const vlu = @import("value.zig");
 const Value = vlu.Value;
-const ValueArray = vlu.ValueArray;
+
+const Chunk = @import("chunk.zig").Chunk;
 
 const ob = @import("object.zig");
 const Obj = ob.Obj;
@@ -134,8 +135,8 @@ pub const GCAllocator = struct {
         }
     }
 
-    fn mark_array(self: *GCAllocator, array: *ValueArray) void {
-        for (array.values.items) |*item| {
+    fn mark_constants(self: *GCAllocator, chunk: *Chunk) void {
+        for (chunk.constants.items) |*item| {
             self.mark_value(item);
         }
     }
@@ -161,7 +162,7 @@ pub const GCAllocator = struct {
                 if (function.name) |name| {
                     self.mark_object(get_obj(ObjString, name));
                 }
-                self.mark_array(&function.chunk.constants);
+                self.mark_constants(&function.chunk);
             },
             .closure => {
                 var closure = obj.as_closure();
@@ -222,7 +223,7 @@ pub const GCAllocator = struct {
                     self.vm.?.objects = current;
                 }
 
-                unreached.deinit();
+                unreached.deinit(gc_allocator);
                 gc_allocator.destroy(unreached);
             }
         }

--- a/src/object.zig
+++ b/src/object.zig
@@ -202,7 +202,7 @@ fn get_or_put_interned_string(
         var obj = alloc_obj(ObjString, new_objstr.*, .string, objects, allocator);
         var objstr = obj.as_string();
         strings.put(objstr, {}) catch {
-            std.debug.print("Out of memory\n", .{});
+            std.log.err("Out of memory\n", .{});
             std.process.exit(1);
         };
         return obj;
@@ -401,7 +401,7 @@ pub const ObjClass = struct {
 
     pub fn inherit(self: *ObjClass, super: *ObjClass) void {
         var new_methods = super.methods.clone() catch {
-            std.debug.print("out of memory\n", .{});
+            std.log.err("out of memory\n", .{});
             std.process.exit(1);
         };
         self.methods.deinit();

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -4,6 +4,20 @@ const std = @import("std");
 const lox = @import("lox.zig");
 const InterpretError = lox.InterpretError;
 
+// Define root.log to override the std implementation
+pub fn log(
+    comptime _: std.log.Level,
+    comptime _: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    // Print the message to stderr, silently ignoring any errors
+    std.debug.getStderrMutex().lock();
+    defer std.debug.getStderrMutex().unlock();
+    const stderr = std.io.getStdErr().writer();
+    nosuspend stderr.print(format, args) catch return;
+}
+
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{
         .retain_metadata = true,

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -100,24 +100,3 @@ fn run_file(vm: *lox.Lox, allocator: std.mem.Allocator, path: []u8) void {
         }
     };
 }
-
-// TODO: make this a test, somewhere
-// var c = lox.chunk.Chunk.init(allocator);
-// defer c.deinit();
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_constant), 1);
-// c.write(c.add_constant(1.2), 1);
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_constant), 2);
-// c.write(c.add_constant(3.4), 2);
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_add), 3);
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_constant), 4);
-// c.write(c.add_constant(5.6), 4);
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_divide), 5);
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_negate), 6);
-//
-// c.write(@enumToInt(lox.chunk.OpCode.op_return), 7);

--- a/src/value.zig
+++ b/src/value.zig
@@ -277,25 +277,3 @@ const ValueUnion = union(enum) {
         }
     }
 };
-
-pub const ValueArray = struct {
-    values: ArrayList(Value),
-
-    pub fn init(allocator: std.mem.Allocator) ValueArray {
-        var arr = ArrayList(Value).init(allocator);
-        return ValueArray{ .values = arr };
-    }
-
-    pub fn deinit(self: *ValueArray) void {
-        self.values.deinit();
-    }
-
-    // if we're out of memory, bail out
-    pub fn write(self: *ValueArray, value: Value) void {
-        common.write_or_die(Value, &self.values, value);
-    }
-
-    pub fn length(self: *ValueArray) usize {
-        return self.values.items.len;
-    }
-};

--- a/src/value.zig
+++ b/src/value.zig
@@ -9,7 +9,7 @@ const Obj = obj.Obj;
 
 pub const Value = if (build_options.value_union) ValueUnion else ValuePack;
 
-const ValuePack = union(enum) {
+const ValuePack = struct {
     payload: u64,
 
     const QNAN: u64 = 0x7ffc000000000000;
@@ -132,7 +132,7 @@ const ValuePack = union(enum) {
         } else if (self.is_number()) {
             try writer.print("{d}", .{self.as_number()});
         } else {
-            try writer.print("{}", .{self.as_obj()});
+            try self.as_obj().print(writer);
         }
     }
 };

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -139,7 +139,7 @@ pub const VM = struct {
         var object: ?*Obj = self.objects;
         while (object) |o| {
             const next: ?*Obj = o.next;
-            o.deinit(self.allocator);
+            o.deinit();
             self.allocator.destroy(o);
             object = next;
         }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -81,7 +81,7 @@ const CallFrame = struct {
     }
 
     fn read_constant(self: *CallFrame) Value {
-        return self.closure.function.chunk.constants.values.items[self.read_byte()];
+        return self.closure.function.chunk.constants.items[self.read_byte()];
     }
 
     fn read_short(self: *CallFrame) u16 {
@@ -139,7 +139,7 @@ pub const VM = struct {
         var object: ?*Obj = self.objects;
         while (object) |o| {
             const next: ?*Obj = o.next;
-            o.deinit();
+            o.deinit(self.allocator);
             self.allocator.destroy(o);
             object = next;
         }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -68,15 +68,19 @@ pub const Options = struct {
 const CallFrame = struct {
     closure: *ObjClosure,
     ip: [*]u8,
-    slots_start: usize,
+    slots_start: [*]Value,
 
-    fn init(closure: *ObjClosure, slots_start: usize) CallFrame {
-        return .{ .closure = closure, .ip = closure.function.chunk.code.items.ptr, .slots_start = slots_start };
+    fn init(closure: *ObjClosure, slots_start: [*]Value) CallFrame {
+        return .{
+            .closure = closure,
+            .ip = closure.function.chunk.code.items.ptr,
+            .slots_start = slots_start,
+        };
     }
 
     fn read_byte(self: *CallFrame) u8 {
         const byte = self.ip[0];
-        self.ip = self.ip + 1;
+        self.ip += 1;
         return byte;
     }
 
@@ -99,9 +103,8 @@ pub const VM = struct {
 
     allocator: std.mem.Allocator,
 
-    // TODO: revisit if this should really use pointer math
-    stack: [STACK_MAX]Value = undefined,
-    stack_top: usize = 0,
+    stack: []Value,
+    stack_top: [*]Value,
 
     objects: ?*Obj = null,
     open_upvalues: ?*ObjUpValue = null,
@@ -118,11 +121,14 @@ pub const VM = struct {
         const gc_allocator = gc.allocator();
         const strings = ObjStringHashMap.init(gc_allocator);
         const globals = VariableHashMap.init(gc_allocator);
+        const stack = common.alloc_or_die(gc_allocator, Value, STACK_MAX);
         var vm = VM{
             .options = options,
             .allocator = gc_allocator,
             .strings = strings,
             .globals = globals,
+            .stack = stack,
+            .stack_top = stack.ptr,
         };
         vm.define_native("clock", clock_native);
         vm.init_string = new_string(&vm.strings, "init", &vm.objects, vm.allocator, false).as_string();
@@ -133,6 +139,7 @@ pub const VM = struct {
         self.free_objects();
         self.strings.deinit();
         self.globals.deinit();
+        self.allocator.free(self.stack);
     }
 
     pub fn free_objects(self: *VM) void {
@@ -146,7 +153,7 @@ pub const VM = struct {
     }
 
     fn reset_stack(self: *VM) void {
-        self.stack_top = 0;
+        self.stack_top = self.stack.ptr;
     }
 
     fn current_frame(self: *VM) *CallFrame {
@@ -154,17 +161,17 @@ pub const VM = struct {
     }
 
     fn push(self: *VM, value: Value) void {
-        self.stack[self.stack_top] = value;
+        self.stack_top.* = value;
         self.stack_top += 1;
     }
 
     fn pop(self: *VM) Value {
         self.stack_top -= 1;
-        return self.stack[self.stack_top];
+        return self.stack_top[0];
     }
 
     fn peek(self: *VM, distance: usize) Value {
-        return self.stack[self.stack_top - 1 - distance];
+        return (self.stack_top - 1 - distance)[0];
     }
 
     fn call(self: *VM, closure: *ObjClosure, arg_count: u8) !void {
@@ -218,14 +225,14 @@ pub const VM = struct {
         while (true) {
             if (self.options.debug_runtime) {
                 // print stack
-                std.debug.print("          ", .{});
-                for (self.stack) |value, i| {
-                    if (i == self.stack_top) {
+                std.log.debug("          ", .{});
+                for (self.stack) |value| {
+                    if (@ptrToInt(&value) == @ptrToInt(self.stack_top)) {
                         break;
                     }
-                    std.debug.print("[{}]", .{value});
+                    std.log.debug("[{}]", .{value});
                 }
-                std.debug.print("\n", .{});
+                std.log.debug("\n", .{});
 
                 _ = disassemble_instruction(&frame.closure.function.chunk, @ptrToInt(frame.ip) - @ptrToInt(frame.closure.function.chunk.code.items.ptr));
             }
@@ -238,7 +245,7 @@ pub const VM = struct {
                 .define_global => {
                     var name = frame.read_string();
                     self.globals.put(name, self.peek(0)) catch {
-                        std.debug.print("Out of memory!\n", .{});
+                        std.log.err("Out of memory!\n", .{});
                         std.process.exit(1);
                     };
                     _ = self.pop();
@@ -263,11 +270,11 @@ pub const VM = struct {
                 },
                 .get_local => {
                     const idx = frame.read_byte();
-                    self.push(self.stack[frame.slots_start + idx]);
+                    self.push(frame.slots_start[idx]);
                 },
                 .set_local => {
                     const idx = frame.read_byte();
-                    self.stack[frame.slots_start + idx] = self.peek(0);
+                    frame.slots_start[idx] = self.peek(0);
                 },
                 .get_property => {
                     if (!self.peek(0).is_instance()) {
@@ -312,7 +319,7 @@ pub const VM = struct {
                     frame.closure.upvalues[slot].?.location.* = self.peek(0);
                 },
                 .close_upvalue => {
-                    self.close_upvalues(&self.stack[self.stack_top - 1]);
+                    self.close_upvalues(self.stack_top - 1);
                     _ = self.pop();
                 },
                 .get_super => {
@@ -336,7 +343,7 @@ pub const VM = struct {
                 },
                 ._return => {
                     const result = self.pop();
-                    self.close_upvalues(&self.stack[frame.slots_start]);
+                    self.close_upvalues(frame.slots_start);
                     self.frame_count -= 1;
                     if (self.frame_count == 0) {
                         _ = self.pop();
@@ -348,7 +355,9 @@ pub const VM = struct {
                     frame = self.current_frame();
                 },
                 .print => {
-                    std.debug.print("{}\n", .{self.pop()});
+                    std.io.getStdOut().writer().print("{}\n", .{self.pop()}) catch {
+                        return InterpretError.runtime;
+                    };
                 },
                 .pop => {
                     _ = self.pop();
@@ -366,7 +375,7 @@ pub const VM = struct {
                         const is_local = frame.read_byte();
                         const index = frame.read_byte();
                         if (is_local == 1) {
-                            upvalue.* = self.capture_upvalue(&self.stack[frame.slots_start + index]);
+                            upvalue.* = self.capture_upvalue(&frame.slots_start[index]);
                         } else {
                             upvalue.* = frame.closure.upvalues[index];
                         }
@@ -501,10 +510,9 @@ pub const VM = struct {
                 },
                 .native => {
                     const native = obj_val.as_native();
-                    var stack_ptr: [*]Value = &self.stack;
                     const result = native.function(
                         arg_count,
-                        stack_ptr + self.stack_top - arg_count,
+                        self.stack_top - arg_count,
                     );
                     self.stack_top -= arg_count + 1;
                     self.push(result);
@@ -512,7 +520,7 @@ pub const VM = struct {
                 },
                 .class => {
                     var class = obj_val.as_class();
-                    self.stack[self.stack_top - arg_count - 1] = Value.obj(new_instance(class, &self.objects, self.allocator));
+                    (self.stack_top - arg_count - 1).* = Value.obj(new_instance(class, &self.objects, self.allocator));
                     if (class.methods.get(self.init_string.?)) |initializer| {
                         return self.call(initializer.as_obj().as_closure(), arg_count);
                     } else if (arg_count > 0) {
@@ -523,7 +531,7 @@ pub const VM = struct {
                 },
                 .bound_method => {
                     var bound = obj_val.as_bound_method();
-                    self.stack[self.stack_top - arg_count - 1] = bound.receiver;
+                    (self.stack_top - arg_count - 1).* = bound.receiver;
                     return self.call(bound.method, arg_count);
                 },
                 else => {},
@@ -558,7 +566,7 @@ pub const VM = struct {
         }
         var instance = receiver.as_obj().as_instance();
         if (instance.fields.get(name)) |value| {
-            self.stack[self.stack_top - arg_count - 1] = value;
+            (self.stack_top - arg_count - 1).* = value;
             return self.call_value(value, arg_count);
         }
         try self.invoke_from_class(instance.class, name, arg_count);
@@ -600,7 +608,7 @@ pub const VM = struct {
         return created_upvalue;
     }
 
-    fn close_upvalues(self: *VM, last: *Value) void {
+    fn close_upvalues(self: *VM, last: [*]Value) void {
         while (self.open_upvalues != null and @ptrToInt(self.open_upvalues.?.location) >= @ptrToInt(last)) {
             var upvalue = self.open_upvalues.?;
             upvalue.closed = upvalue.location.*;
@@ -627,7 +635,7 @@ pub const VM = struct {
             self.allocator,
         )));
         self.globals.put(self.peek(1).as_obj().as_string(), self.peek(0)) catch {
-            std.debug.print("Out of memory!\n", .{});
+            std.log.err("Out of memory!\n", .{});
             std.process.exit(1);
         };
         _ = self.pop();
@@ -639,7 +647,7 @@ pub const VM = struct {
         comptime format: []const u8,
         args: anytype,
     ) void {
-        std.debug.print(format, args);
+        std.log.err(format, args);
 
         var i = self.frame_count;
         while (i > 0) : (i -= 1) {
@@ -647,7 +655,7 @@ pub const VM = struct {
             const chunk = frame.closure.function.chunk;
             const instruction: usize = @ptrToInt(frame.ip) - @ptrToInt(chunk.code.items.ptr) - 1;
             const line: usize = chunk.lines.items[instruction];
-            std.debug.print("[line {d}] in {}\n", .{ line, frame.closure });
+            std.log.err("[line {d}] in {}\n", .{ line, frame.closure });
         }
 
         self.reset_stack();


### PR DESCRIPTION
* always allocate an object header and the object next to each other and return the pointer to the object - this allows pointer casting the item after the header as needed (though kind of funky for printing as that doesn't use a pointer...)
* use `std.log` instead of `std.debug`
* use unmanaged array lists in chunk as they all share the same allocator (saves some bytes)
* get ride of `ValueArray` and just put it inline in `Chunk`
* remove allocators from objects and pass in as needed (saves some bytes)
* make `stack_top` a pointer instead of an index (didn't actually make much of a performance difference)