### PR TITLE
Feat wasm

### DIFF
--- a/.github/workflows/trigger-lox-v-lox.yml
+++ b/.github/workflows/trigger-lox-v-lox.yml
@@ -1,0 +1,20 @@
+name: trigger lox-v-lox rebuild
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+
+  trigger_rebuild:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: rebuild
+      run: |
+        curl \
+          -XPOST \
+          -H "Authorization: Bearer ${{ secrets.LOX_V_LOX_GH_TOKEN }}"  \
+          -H "Accept: application/vnd.github+json"  \
+          https://api.github.com/repos/mcmcgrath13/lox-v-lox/actions/workflows/36915844/dispatches \
+          -d '{"ref": "main"}'

--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.build.Builder) !void {
     exe_options.addOption(bool, "value_union", value_union);
 
     if (wasm_lib) {
-        return try build_wasm(b, exe_options);
+        return build_wasm(b, exe_options);
     }
 
     const exe = b.addExecutable("lox", "src/runner.zig");
@@ -39,7 +39,8 @@ fn build_wasm(b: *std.build.Builder, options: *std.build.OptionsStep) !void {
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardReleaseOptions();
     
-    const lib = b.addStaticLibrary("lox", "src/wasm.zig");
+    const lib = b.addSharedLibrary("lox", "src/wasm.zig", .unversioned);
+    lib.addSystemIncludeDir("src");
     lib.setTarget(try std.zig.CrossTarget.parse(.{.arch_os_abi = "wasm32-freestanding"}));
     lib.addOptions("build_options", options);
     lib.setBuildMode(mode);

--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -94,8 +94,7 @@ pub const Chunk = struct {
         value: T,
     ) void {
         list.append(self.allocator, value) catch {
-            std.log.err("Out of memory\n", .{});
-            std.process.exit(1);
+            @panic("Out o memory\n");
         };
     }
 };

--- a/src/common.zig
+++ b/src/common.zig
@@ -1,32 +1,27 @@
 const std = @import("std");
 const ArrayList = std.ArrayList;
-const exit = std.process.exit;
 
 pub fn write_or_die(comptime T: type, list: *ArrayList(T), value: T) void {
     list.append(value) catch {
-        std.log.err("Out of memory\n", .{});
-        exit(1);
+        @panic("Out of memory\n");
     };
 }
 
 pub fn alloc_or_die(allocator: std.mem.Allocator, comptime T: type, len: usize) []T {
     return allocator.alloc(T, len) catch {
-        std.log.err("Out of memory\n", .{});
-        std.process.exit(1);
+        @panic("Out of memory\n");
     };
 }
 
-pub fn alloc_aligned_or_die(allocator: std.mem.Allocator, len: usize) []align(8) u8 {
-    return allocator.alignedAlloc(u8, 8, len) catch {
-        std.log.err("Out of memory\n", .{});
-        std.process.exit(1);
+pub fn alloc_aligned_or_die(allocator: std.mem.Allocator, comptime alignment: u29, len: usize) []align(alignment) u8 {
+    return allocator.alignedAlloc(u8, alignment, len) catch {
+        @panic("Out of memory\n");
     };
 }
 
 pub fn create_or_die(allocator: std.mem.Allocator, comptime T: type) *T {
     return allocator.create(T) catch {
-        std.log.err("Out of memory\n", .{});
-        std.process.exit(1);
+        @panic("Out of memory\n");
     };
 }
 

--- a/src/value.zig
+++ b/src/value.zig
@@ -46,7 +46,7 @@ const ValuePack = struct {
     }
 
     pub fn as_obj(self: Value) *Obj {
-        return @intToPtr(*Obj, self.payload & ~(SIGN_BIT | QNAN));
+        return @intToPtr(*Obj, @truncate(usize, self.payload & ~(SIGN_BIT | QNAN)));
     }
 
     pub fn is_number(self: Value) bool {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -99,7 +99,7 @@ const CallFrame = struct {
     }
 };
 
-extern fn wasm_print(msg_ptr: [*]const u8, msg_len: usize) void;
+extern "zig" fn wasm_print(msg_ptr: [*]const u8, msg_len: usize) void;
 
 pub const VM = struct {
     frames: [FRAME_MAX]CallFrame = undefined,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -99,6 +99,8 @@ const CallFrame = struct {
     }
 };
 
+extern fn wasm_print(msg_ptr: [*]const u8, msg_len: usize) void;
+
 pub const VM = struct {
     frames: [FRAME_MAX]CallFrame = undefined,
     frame_count: u8 = 0,
@@ -247,8 +249,7 @@ pub const VM = struct {
                 .define_global => {
                     var name = frame.read_string();
                     self.globals.put(name, self.peek(0)) catch {
-                        log.err("Out of memory!\n", .{});
-                        std.process.exit(1);
+                        @panic("Out of memory!\n");
                     };
                     _ = self.pop();
                 },
@@ -357,9 +358,19 @@ pub const VM = struct {
                     frame = self.current_frame();
                 },
                 .print => {
-                    std.io.getStdOut().writer().print("{}\n", .{self.pop()}) catch {
-                        return InterpretError.runtime;
-                    };
+                    if (@hasField(std.os.system, "fd_t")) {
+                        std.io.getStdOut().writer().print("{}\n", .{self.pop()}) catch {
+                            return InterpretError.runtime;
+                        }; 
+                    } else {
+                        // WASM
+                        var str = std.fmt.allocPrint(self.allocator, "{}\n", .{self.pop()}) catch {
+                            return InterpretError.runtime;
+                        };
+                        defer self.allocator.free(str);
+                        wasm_print(str.ptr, str.len);
+                    }
+                                       
                 },
                 .pop => {
                     _ = self.pop();
@@ -637,8 +648,7 @@ pub const VM = struct {
             self.allocator,
         )));
         self.globals.put(self.peek(1).as_obj().as_string(), self.peek(0)) catch {
-            log.err("Out of memory!\n", .{});
-            std.process.exit(1);
+            @panic("Out of memory!\n");
         };
         _ = self.pop();
         _ = self.pop();
@@ -693,5 +703,11 @@ fn greater(left: f64, right: f64) bool {
 fn clock_native(arg_count: u8, args: [*]Value) Value {
     _ = arg_count;
     _ = args;
-    return Value.number(@intToFloat(f64, std.time.timestamp()));
+    if (@hasField(std.os.system, "timespec")) {
+        return Value.number(@intToFloat(f64, std.time.timestamp()));
+    } else {
+        // TODO: what to do when there isn't an os clock?
+        return Value.number(0);
+    }
+    
 }

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -3,18 +3,34 @@ const std = @import("std");
 
 const lox = @import("lox.zig");
 
+extern "zig" fn wasm_print(msg_ptr: [*]const u8, msg_len: usize) void;
+
 // Define root.log to override the std implementation
 pub fn log(
     comptime _: std.log.Level,
     comptime _: @TypeOf(.EnumLiteral),
-    comptime _: []const u8,
-    _: anytype,
+    comptime fmt: []const u8,
+    value: anytype,
 ) void {
     // Print the message to stderr, silently ignoring any errors
     // std.debug.getStderrMutex().lock();
     // defer std.debug.getStderrMutex().unlock();
     // const stderr = std.io.getStdErr().writer();
     // nosuspend stderr.print(format, args) catch return;
+    var gpa = std.heap.GeneralPurposeAllocator(.{
+        .retain_metadata = true,
+        .never_unmap = true,
+        // .verbose_log = true,
+    }){};
+    const allocator = gpa.allocator();
+    defer {
+        const leaked = gpa.deinit();
+        if (leaked) std.testing.expect(false) catch @panic("TEST FAIL"); //fail test; can't try in defer as defer is executed after we return
+    }
+
+    var str = std.fmt.allocPrint(allocator, fmt, value) catch return;
+    defer allocator.free(str);
+    wasm_print(str.ptr, str.len);
 }
 
 export fn run(src: [*:0]const u8, src_len: usize) void {
@@ -36,5 +52,12 @@ export fn run(src: [*:0]const u8, src_len: usize) void {
     defer vm.deinit();
     
     const code: []const u8 = src[0..src_len];
-    vm.interpret(code) catch {};
+    vm.interpret(code) catch {
+        wasm_print("uh oh", 5);
+    };
+}
+
+export fn _wasm_alloc(len: usize) u32 {
+    var buf = std.heap.page_allocator.alloc(u8, len) catch return 0;
+    return @ptrToInt(buf.ptr);
 }

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -3,6 +3,20 @@ const std = @import("std");
 
 const lox = @import("lox.zig");
 
+// Define root.log to override the std implementation
+pub fn log(
+    comptime _: std.log.Level,
+    comptime _: @TypeOf(.EnumLiteral),
+    comptime _: []const u8,
+    _: anytype,
+) void {
+    // Print the message to stderr, silently ignoring any errors
+    // std.debug.getStderrMutex().lock();
+    // defer std.debug.getStderrMutex().unlock();
+    // const stderr = std.io.getStdErr().writer();
+    // nosuspend stderr.print(format, args) catch return;
+}
+
 export fn run(src: [*:0]const u8, src_len: usize) void {
     // TODO change this to the wee allocator?
     var gpa = std.heap.GeneralPurposeAllocator(.{

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -1,0 +1,26 @@
+// this file is the entrypoint for the wasm library
+const std = @import("std");
+
+const lox = @import("lox.zig");
+
+export fn run(src: [*:0]const u8, src_len: usize) void {
+    // TODO change this to the wee allocator?
+    var gpa = std.heap.GeneralPurposeAllocator(.{
+        .retain_metadata = true,
+        .never_unmap = true,
+        // .verbose_log = true,
+    }){};
+    const allocator = gpa.allocator();
+    defer {
+        const leaked = gpa.deinit();
+        if (leaked) std.testing.expect(false) catch @panic("TEST FAIL"); //fail test; can't try in defer as defer is executed after we return
+    }
+
+    // TODO: put debug bool behind an args flag
+    var options = lox.Options{};
+    var vm = lox.Lox.init(options, allocator);
+    defer vm.deinit();
+    
+    const code: []const u8 = src[0..src_len];
+    vm.interpret(code) catch {};
+}


### PR DESCRIPTION
* create build script and entry point for wasm
* rely on `wasm_print` js function for logging and printing
* use `@panic` instead of `exit` (exit not supported in wasm-freestanding target)
* account for 32-bit pointers in `Value`
* clock not allowed in wasm land - just returns 0 for now (maybe use a js function for this as well?