### PR TITLE
fix: string printing, clock millis

### DIFF
--- a/src/object.zig
+++ b/src/object.zig
@@ -104,7 +104,7 @@ pub const Obj = struct {
         writer: anytype,
     ) !void {
         switch (self.t) {
-            .string => try writer.print("\"{s}\"", .{self.as_string()}),
+            .string => try writer.print("{s}", .{self.as_string()}),
             .function => try writer.print("{}", .{self.as_function()}),
             .native => try writer.print("{}", .{self.as_native()}),
             .closure => try writer.print("{}", .{self.as_closure()}),

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -50,7 +50,7 @@ export fn run(src: [*:0]const u8, src_len: usize) void {
     var options = lox.Options{};
     var vm = lox.Lox.init(options, allocator);
     defer vm.deinit();
-    
+
     const code: []const u8 = src[0..src_len];
     vm.interpret(code) catch {
         wasm_print("uh oh", 5);


### PR DESCRIPTION
* don't print strings with quotes
* use the JS clock, and report milliseconds instead of seconds